### PR TITLE
add "Dump icons" command; dumps icons separated by Icon_* subpackage

### DIFF
--- a/GPK_RePack/Forms/GUI.Designer.cs
+++ b/GPK_RePack/Forms/GUI.Designer.cs
@@ -59,6 +59,7 @@ namespace GPK_RePack.Forms
             this.replaceSaveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.savePatchedCompositeStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveAddedCompositeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -123,7 +124,7 @@ namespace GPK_RePack.Forms
             this.ProgressBar = new System.Windows.Forms.ToolStripProgressBar();
             this.splitContainerLog_InfoTree = new System.Windows.Forms.SplitContainer();
             this.boxLog = new System.Windows.Forms.RichTextBox();
-            this.saveAddedCompositeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.dumpIconsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.treeContextMenu.SuspendLayout();
             this.menuStrip.SuspendLayout();
             this.tabControl.SuspendLayout();
@@ -155,7 +156,7 @@ namespace GPK_RePack.Forms
             this.treeMain.HideSelection = false;
             this.treeMain.Location = new System.Drawing.Point(0, 0);
             this.treeMain.Name = "treeMain";
-            this.treeMain.Size = new System.Drawing.Size(321, 450);
+            this.treeMain.Size = new System.Drawing.Size(321, 452);
             this.treeMain.TabIndex = 1;
             this.treeMain.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeMain_AfterSelect);
             this.treeMain.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.treeMain_NodeMouseClick);
@@ -176,7 +177,7 @@ namespace GPK_RePack.Forms
             this.toolStripSeparator6,
             this.previewOGGToolStripMenuItem});
             this.treeContextMenu.Name = "treeContextMenu";
-            this.treeContextMenu.Size = new System.Drawing.Size(161, 184);
+            this.treeContextMenu.Size = new System.Drawing.Size(144, 170);
             this.treeContextMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.treeContextMenu_ItemClicked);
             // 
             // importToolStripMenuItem
@@ -186,26 +187,26 @@ namespace GPK_RePack.Forms
             this.importOGGToolStripMenuItem,
             this.importDDSToolStripMenuItem});
             this.importToolStripMenuItem.Name = "importToolStripMenuItem";
-            this.importToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.importToolStripMenuItem.Text = "Import";
             this.importToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.treeContextMenu_ItemClicked);
             // 
             // importRawDataToolStripMenuItem
             // 
             this.importRawDataToolStripMenuItem.Name = "importRawDataToolStripMenuItem";
-            this.importRawDataToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.importRawDataToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.importRawDataToolStripMenuItem.Text = "Raw Data";
             // 
             // importOGGToolStripMenuItem
             // 
             this.importOGGToolStripMenuItem.Name = "importOGGToolStripMenuItem";
-            this.importOGGToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.importOGGToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.importOGGToolStripMenuItem.Text = "OGG";
             // 
             // importDDSToolStripMenuItem
             // 
             this.importDDSToolStripMenuItem.Name = "importDDSToolStripMenuItem";
-            this.importDDSToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.importDDSToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.importDDSToolStripMenuItem.Text = "DDS";
             // 
             // exportToolStripMenuItem
@@ -216,73 +217,73 @@ namespace GPK_RePack.Forms
             this.exportDDSToolStripMenuItem,
             this.exportPackageToolStripMenuItem});
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-            this.exportToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.exportToolStripMenuItem.Text = "Export";
             this.exportToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.treeContextMenu_ItemClicked);
             // 
             // exportRawDataToolStripMenuItem
             // 
             this.exportRawDataToolStripMenuItem.Name = "exportRawDataToolStripMenuItem";
-            this.exportRawDataToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.exportRawDataToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.exportRawDataToolStripMenuItem.Text = "Raw Data";
             // 
             // exportOGGToolStripMenuItem
             // 
             this.exportOGGToolStripMenuItem.Name = "exportOGGToolStripMenuItem";
-            this.exportOGGToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.exportOGGToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.exportOGGToolStripMenuItem.Text = "OGG";
             // 
             // exportDDSToolStripMenuItem
             // 
             this.exportDDSToolStripMenuItem.Name = "exportDDSToolStripMenuItem";
-            this.exportDDSToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.exportDDSToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.exportDDSToolStripMenuItem.Text = "DDS";
             // 
             // exportPackageToolStripMenuItem
             // 
             this.exportPackageToolStripMenuItem.Name = "exportPackageToolStripMenuItem";
-            this.exportPackageToolStripMenuItem.Size = new System.Drawing.Size(136, 24);
+            this.exportPackageToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.exportPackageToolStripMenuItem.Text = "Package";
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(157, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(140, 6);
             // 
             // addToolStripMenuItem
             // 
             this.addToolStripMenuItem.Enabled = false;
             this.addToolStripMenuItem.Name = "addToolStripMenuItem";
-            this.addToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.addToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.addToolStripMenuItem.Text = "Add";
             // 
             // removeToolStripMenuItem
             // 
             this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-            this.removeToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.removeToolStripMenuItem.Text = "Remove";
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.copyToolStripMenuItem.Text = "Copy";
             // 
             // pasteToolStripMenuItem
             // 
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.pasteToolStripMenuItem.Text = "Paste";
             // 
             // toolStripSeparator6
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(157, 6);
+            this.toolStripSeparator6.Size = new System.Drawing.Size(140, 6);
             // 
             // previewOGGToolStripMenuItem
             // 
             this.previewOGGToolStripMenuItem.Name = "previewOGGToolStripMenuItem";
-            this.previewOGGToolStripMenuItem.Size = new System.Drawing.Size(160, 24);
+            this.previewOGGToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
             this.previewOGGToolStripMenuItem.Text = "Preview OGG";
             // 
             // menuStrip
@@ -294,7 +295,7 @@ namespace GPK_RePack.Forms
             this.miscToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Size = new System.Drawing.Size(1163, 27);
+            this.menuStrip.Size = new System.Drawing.Size(1163, 24);
             this.menuStrip.TabIndex = 2;
             this.menuStrip.Text = "menuStrip1";
             // 
@@ -316,89 +317,96 @@ namespace GPK_RePack.Forms
             this.clearToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.mainToolStripMenuItem.Name = "mainToolStripMenuItem";
-            this.mainToolStripMenuItem.Size = new System.Drawing.Size(52, 23);
+            this.mainToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
             this.mainToolStripMenuItem.Text = "Main";
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(287, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(256, 6);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.saveToolStripMenuItem.Text = "Save (Rebuild Mode)";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // savePaddingStripMenuItem
             // 
             this.savePaddingStripMenuItem.Name = "savePaddingStripMenuItem";
-            this.savePaddingStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.savePaddingStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.savePaddingStripMenuItem.Text = "Save (Rebuild Mode, with Padding)";
             this.savePaddingStripMenuItem.Click += new System.EventHandler(this.savepaddingStripMenuItem_Click);
             // 
             // replaceSaveToolStripMenuItem
             // 
             this.replaceSaveToolStripMenuItem.Name = "replaceSaveToolStripMenuItem";
-            this.replaceSaveToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.replaceSaveToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.replaceSaveToolStripMenuItem.Text = "Save patched (not recommend)";
             this.replaceSaveToolStripMenuItem.Click += new System.EventHandler(this.replaceSaveToolStripMenuItem_Click);
             // 
             // toolStripSeparator7
             // 
             this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(287, 6);
+            this.toolStripSeparator7.Size = new System.Drawing.Size(256, 6);
             // 
             // savePatchedCompositeStripMenuItem
             // 
             this.savePatchedCompositeStripMenuItem.Name = "savePatchedCompositeStripMenuItem";
-            this.savePatchedCompositeStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.savePatchedCompositeStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.savePatchedCompositeStripMenuItem.Text = "Save patched Composite";
             this.savePatchedCompositeStripMenuItem.Click += new System.EventHandler(this.btnSavePatchedComposite_Click);
+            // 
+            // saveAddedCompositeToolStripMenuItem
+            // 
+            this.saveAddedCompositeToolStripMenuItem.Name = "saveAddedCompositeToolStripMenuItem";
+            this.saveAddedCompositeToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
+            this.saveAddedCompositeToolStripMenuItem.Text = "Save added Composite";
+            this.saveAddedCompositeToolStripMenuItem.Click += new System.EventHandler(this.saveAddedCompositeToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(287, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(256, 6);
             // 
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.settingsToolStripMenuItem.Text = "Settings";
             this.settingsToolStripMenuItem.Click += new System.EventHandler(this.settingsToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(287, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(256, 6);
             // 
             // refreshViewToolStripMenuItem
             // 
             this.refreshViewToolStripMenuItem.Name = "refreshViewToolStripMenuItem";
-            this.refreshViewToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.refreshViewToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.refreshViewToolStripMenuItem.Text = "Refresh View";
             this.refreshViewToolStripMenuItem.Click += new System.EventHandler(this.refreshViewToolStripMenuItem_Click);
             // 
             // clearToolStripMenuItem
             // 
             this.clearToolStripMenuItem.Name = "clearToolStripMenuItem";
-            this.clearToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.clearToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.clearToolStripMenuItem.Text = "Clear";
             this.clearToolStripMenuItem.Click += new System.EventHandler(this.clearToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(259, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -409,43 +417,44 @@ namespace GPK_RePack.Forms
             this.datEncryptionToolStripMenuItem,
             this.loadMappingToolStripMenuItem,
             this.writeMappingsToolStripMenuItem,
-            this.dumpCompositeTexturesToolStripMenuItem});
+            this.dumpCompositeTexturesToolStripMenuItem,
+            this.dumpIconsToolStripMenuItem});
             this.compositeGPKToolStripMenuItem.Name = "compositeGPKToolStripMenuItem";
-            this.compositeGPKToolStripMenuItem.Size = new System.Drawing.Size(117, 23);
+            this.compositeGPKToolStripMenuItem.Size = new System.Drawing.Size(102, 20);
             this.compositeGPKToolStripMenuItem.Text = "Composite GPK";
             // 
             // decryptionToolStripMenuItem
             // 
             this.decryptionToolStripMenuItem.Name = "decryptionToolStripMenuItem";
-            this.decryptionToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.decryptionToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.decryptionToolStripMenuItem.Text = ".dat Decryption";
             this.decryptionToolStripMenuItem.Click += new System.EventHandler(this.decryptionToolStripMenuItem_Click);
             // 
             // datEncryptionToolStripMenuItem
             // 
             this.datEncryptionToolStripMenuItem.Name = "datEncryptionToolStripMenuItem";
-            this.datEncryptionToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.datEncryptionToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.datEncryptionToolStripMenuItem.Text = ".dat Encryption";
             this.datEncryptionToolStripMenuItem.Click += new System.EventHandler(this.datEncryptionToolStripMenuItem_Click);
             // 
             // loadMappingToolStripMenuItem
             // 
             this.loadMappingToolStripMenuItem.Name = "loadMappingToolStripMenuItem";
-            this.loadMappingToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.loadMappingToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.loadMappingToolStripMenuItem.Text = "Load/Show Mapping";
             this.loadMappingToolStripMenuItem.Click += new System.EventHandler(this.loadMappingToolStripMenuItem_Click);
             // 
             // writeMappingsToolStripMenuItem
             // 
             this.writeMappingsToolStripMenuItem.Name = "writeMappingsToolStripMenuItem";
-            this.writeMappingsToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.writeMappingsToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.writeMappingsToolStripMenuItem.Text = "Write Mappings";
             this.writeMappingsToolStripMenuItem.Click += new System.EventHandler(this.writeMappingsToolStripMenuItem_Click);
             // 
             // dumpCompositeTexturesToolStripMenuItem
             // 
             this.dumpCompositeTexturesToolStripMenuItem.Name = "dumpCompositeTexturesToolStripMenuItem";
-            this.dumpCompositeTexturesToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.dumpCompositeTexturesToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
             this.dumpCompositeTexturesToolStripMenuItem.Text = "Dump CompositeTextures";
             this.dumpCompositeTexturesToolStripMenuItem.Click += new System.EventHandler(this.dumpCompositeTexturesToolStripMenuItem_Click);
             // 
@@ -463,13 +472,13 @@ namespace GPK_RePack.Forms
             this.searchForObjectToolStripMenuItem,
             this.nextToolStripMenuItem});
             this.miscToolStripMenuItem.Name = "miscToolStripMenuItem";
-            this.miscToolStripMenuItem.Size = new System.Drawing.Size(49, 23);
+            this.miscToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.miscToolStripMenuItem.Text = "Misc";
             // 
             // setFilesizeToolStripMenuItem
             // 
             this.setFilesizeToolStripMenuItem.Name = "setFilesizeToolStripMenuItem";
-            this.setFilesizeToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.setFilesizeToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.setFilesizeToolStripMenuItem.Text = "Set Filesize";
             this.setFilesizeToolStripMenuItem.Click += new System.EventHandler(this.setFilesizeToolStripMenuItem_Click);
             // 
@@ -479,48 +488,48 @@ namespace GPK_RePack.Forms
             this.setAllVolumeMultipliersToolStripMenuItem,
             this.customToolStripMenuItem});
             this.setAllPropertysToolStripMenuItem.Name = "setAllPropertysToolStripMenuItem";
-            this.setAllPropertysToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.setAllPropertysToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.setAllPropertysToolStripMenuItem.Text = "Set all Properties";
             // 
             // setAllVolumeMultipliersToolStripMenuItem
             // 
             this.setAllVolumeMultipliersToolStripMenuItem.Name = "setAllVolumeMultipliersToolStripMenuItem";
-            this.setAllVolumeMultipliersToolStripMenuItem.Size = new System.Drawing.Size(228, 24);
+            this.setAllVolumeMultipliersToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
             this.setAllVolumeMultipliersToolStripMenuItem.Text = "Set all VolumeMultipliers";
             this.setAllVolumeMultipliersToolStripMenuItem.Click += new System.EventHandler(this.setAllVolumeMultipliersToolStripMenuItem_Click);
             // 
             // customToolStripMenuItem
             // 
             this.customToolStripMenuItem.Name = "customToolStripMenuItem";
-            this.customToolStripMenuItem.Size = new System.Drawing.Size(228, 24);
+            this.customToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
             this.customToolStripMenuItem.Text = "Custom";
             this.customToolStripMenuItem.Click += new System.EventHandler(this.customToolStripMenuItem_Click);
             // 
             // tESTBigBytePropExportToolStripMenuItem
             // 
             this.tESTBigBytePropExportToolStripMenuItem.Name = "tESTBigBytePropExportToolStripMenuItem";
-            this.tESTBigBytePropExportToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.tESTBigBytePropExportToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.tESTBigBytePropExportToolStripMenuItem.Text = "Big ByteProp Export";
             this.tESTBigBytePropExportToolStripMenuItem.Click += new System.EventHandler(this.BigBytePropExport_Click);
             // 
             // bigBytePropImportToolStripMenuItem
             // 
             this.bigBytePropImportToolStripMenuItem.Name = "bigBytePropImportToolStripMenuItem";
-            this.bigBytePropImportToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.bigBytePropImportToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.bigBytePropImportToolStripMenuItem.Text = "Big ByteProp Import";
             this.bigBytePropImportToolStripMenuItem.Click += new System.EventHandler(this.BigBytePropImport_Click);
             // 
             // addNameToolStripMenuItem
             // 
             this.addNameToolStripMenuItem.Name = "addNameToolStripMenuItem";
-            this.addNameToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.addNameToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.addNameToolStripMenuItem.Text = "Add Name";
             this.addNameToolStripMenuItem.Click += new System.EventHandler(this.addNameToolStripMenuItem_Click);
             // 
             // dumpHeadersMenuItem
             // 
             this.dumpHeadersMenuItem.Name = "dumpHeadersMenuItem";
-            this.dumpHeadersMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.dumpHeadersMenuItem.Size = new System.Drawing.Size(212, 22);
             this.dumpHeadersMenuItem.Text = "Dump GPK Headers";
             this.dumpHeadersMenuItem.Click += new System.EventHandler(this.dumpHeadersMenuItem_Click);
             // 
@@ -530,26 +539,26 @@ namespace GPK_RePack.Forms
             this.loggingActiveMenuItem.CheckOnClick = true;
             this.loggingActiveMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.loggingActiveMenuItem.Name = "loggingActiveMenuItem";
-            this.loggingActiveMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.loggingActiveMenuItem.Size = new System.Drawing.Size(212, 22);
             this.loggingActiveMenuItem.Text = "Textbox Logging active";
             this.loggingActiveMenuItem.CheckedChanged += new System.EventHandler(this.loggingActiveMenuItem_CheckedChanged);
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(233, 6);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(209, 6);
             // 
             // searchForObjectToolStripMenuItem
             // 
             this.searchForObjectToolStripMenuItem.Name = "searchForObjectToolStripMenuItem";
-            this.searchForObjectToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.searchForObjectToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.searchForObjectToolStripMenuItem.Text = "Search for object (CTRL-F)";
             this.searchForObjectToolStripMenuItem.Click += new System.EventHandler(this.searchForObjectToolStripMenuItem_Click);
             // 
             // nextToolStripMenuItem
             // 
             this.nextToolStripMenuItem.Name = "nextToolStripMenuItem";
-            this.nextToolStripMenuItem.Size = new System.Drawing.Size(236, 24);
+            this.nextToolStripMenuItem.Size = new System.Drawing.Size(212, 22);
             this.nextToolStripMenuItem.Text = "Next result (F3)";
             this.nextToolStripMenuItem.Click += new System.EventHandler(this.nextToolStripMenuItem_Click);
             // 
@@ -562,7 +571,7 @@ namespace GPK_RePack.Forms
             this.tabControl.Location = new System.Drawing.Point(0, 0);
             this.tabControl.Name = "tabControl";
             this.tabControl.SelectedIndex = 0;
-            this.tabControl.Size = new System.Drawing.Size(838, 522);
+            this.tabControl.Size = new System.Drawing.Size(838, 524);
             this.tabControl.TabIndex = 3;
             this.tabControl.Selected += new System.Windows.Forms.TabControlEventHandler(this.tabControl_Selected);
             // 
@@ -573,7 +582,7 @@ namespace GPK_RePack.Forms
             this.tabInfo.Location = new System.Drawing.Point(4, 22);
             this.tabInfo.Name = "tabInfo";
             this.tabInfo.Padding = new System.Windows.Forms.Padding(3);
-            this.tabInfo.Size = new System.Drawing.Size(830, 496);
+            this.tabInfo.Size = new System.Drawing.Size(830, 498);
             this.tabInfo.TabIndex = 0;
             this.tabInfo.Text = "Info";
             this.tabInfo.UseVisualStyleBackColor = true;
@@ -586,7 +595,7 @@ namespace GPK_RePack.Forms
             this.boxInfo.Name = "boxInfo";
             this.boxInfo.ReadOnly = true;
             this.boxInfo.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.boxInfo.Size = new System.Drawing.Size(824, 382);
+            this.boxInfo.Size = new System.Drawing.Size(824, 384);
             this.boxInfo.TabIndex = 5;
             this.boxInfo.Text = resources.GetString("boxInfo.Text");
             // 
@@ -608,7 +617,7 @@ namespace GPK_RePack.Forms
             this.boxDataButtons.Controls.Add(this.btnPreviewOgg, 2, 2);
             this.boxDataButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.boxDataButtons.Enabled = false;
-            this.boxDataButtons.Location = new System.Drawing.Point(3, 385);
+            this.boxDataButtons.Location = new System.Drawing.Point(3, 387);
             this.boxDataButtons.Name = "boxDataButtons";
             this.boxDataButtons.RowCount = 3;
             this.boxDataButtons.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 25F));
@@ -888,7 +897,7 @@ namespace GPK_RePack.Forms
             this.boxGeneralButtons.Controls.Add(this.btnPaste, 1, 1);
             this.boxGeneralButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.boxGeneralButtons.Enabled = false;
-            this.boxGeneralButtons.Location = new System.Drawing.Point(0, 450);
+            this.boxGeneralButtons.Location = new System.Drawing.Point(0, 452);
             this.boxGeneralButtons.MinimumSize = new System.Drawing.Size(50, 50);
             this.boxGeneralButtons.Name = "boxGeneralButtons";
             this.boxGeneralButtons.RowCount = 2;
@@ -960,7 +969,7 @@ namespace GPK_RePack.Forms
             // splitContainerTreeInfo.Panel2
             // 
             this.splitContainerTreeInfo.Panel2.Controls.Add(this.tabControl);
-            this.splitContainerTreeInfo.Size = new System.Drawing.Size(1163, 522);
+            this.splitContainerTreeInfo.Size = new System.Drawing.Size(1163, 524);
             this.splitContainerTreeInfo.SplitterDistance = 321;
             this.splitContainerTreeInfo.TabIndex = 7;
             // 
@@ -999,7 +1008,7 @@ namespace GPK_RePack.Forms
             // splitContainerLog_InfoTree
             // 
             this.splitContainerLog_InfoTree.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainerLog_InfoTree.Location = new System.Drawing.Point(0, 27);
+            this.splitContainerLog_InfoTree.Location = new System.Drawing.Point(0, 24);
             this.splitContainerLog_InfoTree.Name = "splitContainerLog_InfoTree";
             this.splitContainerLog_InfoTree.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -1010,8 +1019,8 @@ namespace GPK_RePack.Forms
             // splitContainerLog_InfoTree.Panel2
             // 
             this.splitContainerLog_InfoTree.Panel2.Controls.Add(this.boxLog);
-            this.splitContainerLog_InfoTree.Size = new System.Drawing.Size(1163, 651);
-            this.splitContainerLog_InfoTree.SplitterDistance = 522;
+            this.splitContainerLog_InfoTree.Size = new System.Drawing.Size(1163, 654);
+            this.splitContainerLog_InfoTree.SplitterDistance = 524;
             this.splitContainerLog_InfoTree.TabIndex = 9;
             // 
             // boxLog
@@ -1020,16 +1029,16 @@ namespace GPK_RePack.Forms
             this.boxLog.Location = new System.Drawing.Point(0, 0);
             this.boxLog.Name = "boxLog";
             this.boxLog.ReadOnly = true;
-            this.boxLog.Size = new System.Drawing.Size(1163, 125);
+            this.boxLog.Size = new System.Drawing.Size(1163, 126);
             this.boxLog.TabIndex = 0;
             this.boxLog.Text = "";
             // 
-            // saveAddedCompositeToolStripMenuItem
+            // dumpIconsToolStripMenuItem
             // 
-            this.saveAddedCompositeToolStripMenuItem.Name = "saveAddedCompositeToolStripMenuItem";
-            this.saveAddedCompositeToolStripMenuItem.Size = new System.Drawing.Size(290, 24);
-            this.saveAddedCompositeToolStripMenuItem.Text = "Save added Composite";
-            this.saveAddedCompositeToolStripMenuItem.Click += new System.EventHandler(this.saveAddedCompositeToolStripMenuItem_Click);
+            this.dumpIconsToolStripMenuItem.Name = "dumpIconsToolStripMenuItem";
+            this.dumpIconsToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
+            this.dumpIconsToolStripMenuItem.Text = "Dump icons";
+            this.dumpIconsToolStripMenuItem.Click += new System.EventHandler(this.dumpIconsToolStripMenuItem_Click);
             // 
             // GUI
             // 
@@ -1173,6 +1182,7 @@ namespace GPK_RePack.Forms
         private ToolStripMenuItem datEncryptionToolStripMenuItem;
         private ToolStripMenuItem writeMappingsToolStripMenuItem;
         private ToolStripMenuItem saveAddedCompositeToolStripMenuItem;
+        private ToolStripMenuItem dumpIconsToolStripMenuItem;
     }
 }
 

--- a/GPK_RePack/Forms/GUI.cs
+++ b/GPK_RePack/Forms/GUI.cs
@@ -1550,7 +1550,37 @@ namespace GPK_RePack.Forms
             var outDir = dialog.SelectedPath;
             new Task(() => MassDumper.DumpMassTextures(gpkStore, outDir, filterList)).Start();
         }
+        private void dumpIconsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            //cookedpc path, outdir path
+            var dialog = new FolderBrowserDialog();
+            if (Settings.Default.CookedPCPath != "")
+                dialog.SelectedPath = Settings.Default.CookedPCPath;
+            dialog.Description = "Select a folder with PkgMapper.dat and CompositePackageMapper.dat in it. Normally your CookedPC folder.";
+            if (dialog.ShowDialog() == DialogResult.Cancel)
+                return;
+            var path = dialog.SelectedPath;
+            gpkStore.BaseSearchPath = path;
+            Settings.Default.CookedPCPath = path;
+            MapperTools.ParseMappings(path, gpkStore);
 
+            int subCount = gpkStore.CompositeMap.Sum(entry => entry.Value.Count);
+            logger.Info("Parsed mappings, we have {0} composite GPKs and {1} sub-gpks!", gpkStore.CompositeMap.Count, subCount);
+            var list = filterCompositeList("");
+            //save dir
+            dialog = new FolderBrowserDialog();
+            dialog.SelectedPath = Settings.Default.WorkingDir;
+            dialog.Description = "Select your output dir";
+            if (dialog.ShowDialog() == DialogResult.Cancel)
+                return;
+            logger.Warn("Warning: This function can be ultra long running (hours) and unstable. Monitor logfile and output folder for progress.");
+            logger.Warn("Disabling logging, dump is running in the background. Consider setting file logging to only info.");
+
+            NLogConfig.DisableFormLogging();
+            var outDir = dialog.SelectedPath;
+            new Task(() => MassDumper.DumpMassIcons(gpkStore, outDir, list)).Start();
+
+        }
         private Dictionary<String, List<CompositeMapEntry>> filterCompositeList(string text)
         {
             try
@@ -2098,6 +2128,7 @@ namespace GPK_RePack.Forms
                 logger.Info("Single export done!");
             }
         }
+
 
 
 


### PR DESCRIPTION
Exported icons preserve the old package names, eg:

```
out_dir/Icon_Skills/Acrobat_Tex.dds
out_dir/Icon_Items/abion_SteelFragment_Tex.dds
```
